### PR TITLE
Getting rebar to compile docs

### DIFF
--- a/src/folsom_webmachine_sup.erl
+++ b/src/folsom_webmachine_sup.erl
@@ -18,11 +18,9 @@
 %%%-------------------------------------------------------------------
 %%% File:      folsom_webmachine_sup.erl
 %%% @author    joe williams <j@boundary.com>
-%%% @doc
+%%% @doc Supervisor for the folsom application.
 %%% @end
 %%%------------------------------------------------------------------
-
-%% @doc Supervisor for the folsom application.
 
 -module(folsom_webmachine_sup).
 


### PR DESCRIPTION
./rebar doc doesn't work in master due to multiple @doc entries on a module.  Removed the extra one.
